### PR TITLE
Corrected example use of js-base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ const clientID = "496357551512441271";
 const client_secret = "cKlFh_71_OXfGVN1hmArPnL8SfKF41kA";
 const access_token = "2qRZcUqUa9816RVnnEKRpzOL2CvHBgF";
 
-const Base64 = require("js-base64").base64;
+const Base64 = require("js-base64").Base64;
 // You must encode your client ID along with your client secret string including the colon in between
-const credentials = Base64(`${clientID}:${client_secret}`); // NDkwNTU3NTkxNTQyNDMxNzc1OmNLbG9oXzc4X09YV0dWTjFobU9ycm5MOFNmS0Y0MWt3
+const credentials = Base64.encode(`${clientID}:${client_secret}`); // NDkwNTU3NTkxNTQyNDMxNzc1OmNLbG9oXzc4X09YV0dWTjFobU9ycm5MOFNmS0Y0MWt3
 
 oauth.revokeToken(access_token, credentials).then(console.log); // {}
 ```


### PR DESCRIPTION
It used to output an error stating, "Base64 is not a function"