### PR TITLE
add prompt to generateAuthUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ Only takes an object with the following properties:
 
 `clientId`: Your application's client id. Can be omitted if provided on the client constructor.
 
+`prompt`: Controls how existing authorizations are handled, either consent or none (for passthrough scopes authorization is always required). Defaults to consent.
+
 `scope`: The scopes requested in your authorization url, can be either a space-delimited string of scopes, or an array of strings containing scopes.
 
 `redirectUri`: Your URL redirect uri. Can be omitted if provided on the client constructor.

--- a/index.d.ts
+++ b/index.d.ts
@@ -109,6 +109,7 @@ declare class OAuth extends EventEmitter {
 		scope: string[] | string,
 		state?: string,
 		clientId?: string,
+		prompt?: "consent" | "none",
 		redirectUri?: string,
 		responseType?: "code" | "token",
 	}): string;

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -186,6 +186,7 @@ class OAuth extends RequestHandler {
 	 * 
 	 * @arg {Object} opts
 	 * @arg {String} opts.clientId Your application's client id
+	 * @arg {String?} opts.prompt Controls how existing authorizations are handled, either consent or none (for passthrough scopes authorization is always required). Defaults to consent
 	 * @arg {String?} opts.redirectUri Your URL redirect uri
 	 * @arg {String?} opts.responseType The response type, either code or token (token is for client-side web applications only). Defaults to code
 	 * @arg {String | Array} opts.scope The scopes for your URL
@@ -195,6 +196,7 @@ class OAuth extends RequestHandler {
 	generateAuthUrl(opts = {}) {
 		const obj = {
 			client_id: opts.clientId || this.client_id,
+			prompt: opts.prompt || "consent",
 			redirect_uri: opts.redirectUri || this.redirect_uri,
 			response_type: opts.responseType || "code",
 			scope: opts.scope instanceof Array ? opts.scope.join(" ") : opts.scope,


### PR DESCRIPTION
`prompt` controls how the authorization flow handles existing authorizations. If a user has previously authorized your application with the requested scopes and prompt is set to `consent`, it will request them to reapprove their authorization. If set to `none`, it will skip the authorization screen and redirect them back to your redirect URI without requesting their authorization. For passthrough scopes, like `bot` and `webhook.incoming`, authorization is always required.

https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-authorization-url-example