### PR TITLE
Add bot specific parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,11 +290,11 @@ Only takes an object with the following properties:
 
 `state`: A unique cryptographically secure string (https://discord.com/developers/docs/topics/oauth2#state-and-security).
 
-`permissions`: The permissions for the bot invite (only with bot scope).
+`permissions`: The permissions number for the bot invite (only with bot scope) (https://discord.com/developers/docs/topics/permissions).
 
-`guild_id`: The guild id to pre-fill the bot invite (only with bot scope).
+`guildId`: The guild id to pre-fill the bot invite (only with bot scope).
 
-`disable_guild_select`: Disallows the user from changing the guild for the bot invite, either true or false (only with bot scope).
+`disableGuildSelect`: Disallows the user from changing the guild for the bot invite, either true or false (only with bot scope).
 
 ```js
 const crypto = require('crypto')

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ oauth.getUserGuilds(access_token).then(console.log);
 		"name": "1337 Krew",
 		"icon": "8342729096ea3675442027381ff50dfe",
 		"owner": true,
-		"permissions": 36953089
+		"permissions": 36953089,
+		"permissions_new": "36953089"
 	}
 */
 ```
@@ -279,7 +280,7 @@ Only takes an object with the following properties:
 
 `clientId`: Your application's client id. Can be omitted if provided on the client constructor.
 
-`prompt`: Controls how existing authorizations are handled, either consent or none (for passthrough scopes authorization is always required). Defaults to consent.
+`prompt`: Controls how existing authorizations are handled, either consent or none (for passthrough scopes authorization is always required).
 
 `scope`: The scopes requested in your authorization url, can be either a space-delimited string of scopes, or an array of strings containing scopes.
 
@@ -288,6 +289,12 @@ Only takes an object with the following properties:
 `responseType`: The response type, either code or token (token is for client-side web applications only). Defaults to code.
 
 `state`: A unique cryptographically secure string (https://discord.com/developers/docs/topics/oauth2#state-and-security).
+
+`permissions`: The permissions for the bot invite (only with bot scope).
+
+`guild_id`: The guild id to pre-fill the bot invite (only with bot scope).
+
+`disable_guild_select`: Disallows the user from changing the guild for the bot invite, either true or false (only with bot scope).
 
 ```js
 const crypto = require('crypto')

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,6 +68,7 @@ interface PartialGuild {
 	owner: boolean;
 	features: string[];
 	permissions?: number;
+	permissions_new?: string;
 }
 
 declare class OAuth extends EventEmitter {

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,9 @@ declare class OAuth extends EventEmitter {
 		prompt?: "consent" | "none",
 		redirectUri?: string,
 		responseType?: "code" | "token",
+		permissions?: string | number,
+		guild_id?: string,
+		disable_guild_select?: boolean,
 	}): string;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -113,9 +113,9 @@ declare class OAuth extends EventEmitter {
 		prompt?: "consent" | "none",
 		redirectUri?: string,
 		responseType?: "code" | "token",
-		permissions?: string | number,
-		guild_id?: string,
-		disable_guild_select?: boolean,
+		permissions?: number,
+		guildId?: string,
+		disableGuildSelect?: boolean,
 	}): string;
 }
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -186,20 +186,26 @@ class OAuth extends RequestHandler {
 	 * 
 	 * @arg {Object} opts
 	 * @arg {String} opts.clientId Your application's client id
-	 * @arg {String?} opts.prompt Controls how existing authorizations are handled, either consent or none (for passthrough scopes authorization is always required). Defaults to consent
+	 * @arg {String?} opts.prompt Controls how existing authorizations are handled, either consent or none (for passthrough scopes authorization is always required).
 	 * @arg {String?} opts.redirectUri Your URL redirect uri
 	 * @arg {String?} opts.responseType The response type, either code or token (token is for client-side web applications only). Defaults to code
 	 * @arg {String | Array} opts.scope The scopes for your URL
+	 * @arg {String? | Number?} opts.permissions The permissions for the bot invite (only with bot scope)
+	 * @arg {String?} opts.guild_id The guild id to pre-fill the bot invite (only with bot scope)
+	 * @arg {Boolean?} opts.disable_guild_select Disallows the user from changing the guild for the bot invite, either true or false (only with bot scope)
 	 * @arg {String?} opts.state A unique cryptographically secure string (https://discord.com/developers/docs/topics/oauth2#state-and-security)
 	 * @returns {String}
 	*/
 	generateAuthUrl(opts = {}) {
 		const obj = {
 			client_id: opts.clientId || this.client_id,
-			prompt: opts.prompt || "consent",
+			prompt: opts.prompt || undefined,
 			redirect_uri: opts.redirectUri || this.redirect_uri,
 			response_type: opts.responseType || "code",
 			scope: opts.scope instanceof Array ? opts.scope.join(" ") : opts.scope,
+			permissions: opts.permissions || undefined,
+			guild_id: opts.guild_id || undefined,
+			disable_guild_select: opts.disable_guild_select || undefined,
 			state: opts.state || undefined,
 		};
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -190,10 +190,10 @@ class OAuth extends RequestHandler {
 	 * @arg {String?} opts.redirectUri Your URL redirect uri
 	 * @arg {String?} opts.responseType The response type, either code or token (token is for client-side web applications only). Defaults to code
 	 * @arg {String | Array} opts.scope The scopes for your URL
+	 * @arg {String?} opts.state A unique cryptographically secure string (https://discord.com/developers/docs/topics/oauth2#state-and-security)
 	 * @arg {String? | Number?} opts.permissions The permissions for the bot invite (only with bot scope)
 	 * @arg {String?} opts.guild_id The guild id to pre-fill the bot invite (only with bot scope)
 	 * @arg {Boolean?} opts.disable_guild_select Disallows the user from changing the guild for the bot invite, either true or false (only with bot scope)
-	 * @arg {String?} opts.state A unique cryptographically secure string (https://discord.com/developers/docs/topics/oauth2#state-and-security)
 	 * @returns {String}
 	*/
 	generateAuthUrl(opts = {}) {

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -191,9 +191,9 @@ class OAuth extends RequestHandler {
 	 * @arg {String?} opts.responseType The response type, either code or token (token is for client-side web applications only). Defaults to code
 	 * @arg {String | Array} opts.scope The scopes for your URL
 	 * @arg {String?} opts.state A unique cryptographically secure string (https://discord.com/developers/docs/topics/oauth2#state-and-security)
-	 * @arg {String? | Number?} opts.permissions The permissions for the bot invite (only with bot scope)
-	 * @arg {String?} opts.guild_id The guild id to pre-fill the bot invite (only with bot scope)
-	 * @arg {Boolean?} opts.disable_guild_select Disallows the user from changing the guild for the bot invite, either true or false (only with bot scope)
+	 * @arg {Number?} opts.permissions The permissions number for the bot invite (only with bot scope) (https://discord.com/developers/docs/topics/permissions)
+	 * @arg {String?} opts.guildId The guild id to pre-fill the bot invite (only with bot scope)
+	 * @arg {Boolean?} opts.disableGuildSelect Disallows the user from changing the guild for the bot invite, either true or false (only with bot scope)
 	 * @returns {String}
 	*/
 	generateAuthUrl(opts = {}) {
@@ -204,8 +204,8 @@ class OAuth extends RequestHandler {
 			response_type: opts.responseType || "code",
 			scope: opts.scope instanceof Array ? opts.scope.join(" ") : opts.scope,
 			permissions: opts.permissions || undefined,
-			guild_id: opts.guild_id || undefined,
-			disable_guild_select: opts.disable_guild_select || undefined,
+			guild_id: opts.guildId || undefined,
+			disable_guild_select: opts.disableGuildSelect || undefined,
 			state: opts.state || undefined,
 		};
 


### PR DESCRIPTION
Added parameters that only exist for the `bot` scope. The bot scope can be used together with other scopes and it seems useful to support the parameters just in case. 

https://discord.com/developers/docs/topics/oauth2#bot-authorization-flow-bot-auth-parameters


I also made the promp parameter not show up for every url and added `permissions_new` to the partial guild doc.