### PR TITLE
Added removeMember (line: 195-204)

### DIFF
--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -181,7 +181,28 @@ class OAuth extends RequestHandler {
 			contentType: "application/json",
 		});
 	}
-
+	
+	/**
+	 * Force a user to leave the guild
+	 * @arg {Object} opts
+	 * @arg {String} opts.guildId The ID of the guild to leave
+	 * @arg {String} opts.userId The ID of the user to be removed from the guild
+	 * @arg {String} opts.accessToken The user access token
+	 * @arg {String} opts.botToken The token of the bot used to authenticate
+	 * @returns {Promise<Object | String>}
+	 * Added By CyberCDN (https://github.com/CyberCDN/)
+	 */
+	removeMember(opts) {
+		return this.request("DELETE", `/guilds/{opts.guildId}/members/{opts.userId}`, {},
+		{ 
+		   auth: {
+			   type: "Bot",
+			   creds: opts.botToken,
+		   },
+		   contentType: "application/json",
+		});
+	}
+	
 	/**
 	 * 
 	 * @arg {Object} opts


### PR DESCRIPTION
I recently discovered you can remove a guild member via `DELETE/guilds/{guild.id}/members/{user.id}` which is documented [here](https://discord.com/developers/docs/resources/guild#remove-guild-member) so I thought I would suggest this be added.