### PR TITLE
Update visibility type in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ interface Connection {
 	name: string;
 	revoked?: string;
 	verified: string;
-	visibility: string;
+	visibility: 0 | 1;
 	friend_sync: boolean;
 	show_activity: boolean;
 	integrations?: Integration[];


### PR DESCRIPTION
According to https://discord.com/developers/docs/resources/user#connection-object, `visibility` is a number that can be either 0 or 1.  In discord-oauth2, this is currently a `string`, which does not match.

This pull request updates the typings for discord-oauth2 to match Discord's documentation.