### PR TITLE
🏷️ Export Interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,88 +1,90 @@
 import { EventEmitter } from "events";
 
-interface User {
-	id: string;
-	username: string;
-	discriminator: string;
-	avatar: string | null | undefined;
-	mfa_enabled?: true;
-	locale?: string;
-	verified?: boolean;
-	email?: string | null | undefined;
-	flags?: number;
-	premium_type?: number;
-	public_flags?: number;
-}
+declare namespace OAuth {
+	export interface User {
+		id: string;
+		username: string;
+		discriminator: string;
+		avatar: string | null | undefined;
+		mfa_enabled?: true;
+		locale?: string;
+		verified?: boolean;
+		email?: string | null | undefined;
+		flags?: number;
+		premium_type?: number;
+		public_flags?: number;
+	}
 
-interface Member {
-	user?: User;
-	nick: string | null | undefined;
-	roles: string[];
-	joined_at: number;
-	premium_since?: number | null | undefined;
-	deaf: boolean;
-	mute: boolean;
-}
+	export interface Member {
+		user?: User;
+		nick: string | null | undefined;
+		roles: string[];
+		joined_at: number;
+		premium_since?: number | null | undefined;
+		deaf: boolean;
+		mute: boolean;
+	}
 
-// This is not accurate as discord sends a partial object
-interface Integration {
-	id: string;
-	name: string;
-	type: string;
-	enabled: boolean;
-	syncing: boolean;
-	role_id: string;
-	enable_emoticons?: boolean;
-	expire_behavior: 0 | 1;
-	expire_grace_period: number;
-	user?: User;
-	account: {
+	// This is not accurate as discord sends a partial object
+	export interface Integration {
 		id: string;
 		name: string;
-	};
-	synced_at: number;
-	subscriber_count: number;	
-	revoked: boolean;
-	application?: Application;
-}
+		type: string;
+		enabled: boolean;
+		syncing: boolean;
+		role_id: string;
+		enable_emoticons?: boolean;
+		expire_behavior: 0 | 1;
+		expire_grace_period: number;
+		user?: User;
+		account: {
+			id: string;
+			name: string;
+		};
+		synced_at: number;
+		subscriber_count: number;	
+		revoked: boolean;
+		application?: Application;
+	}
 
-interface Connection {
-	id: string;
-	name: string;
-	type: string;
-	revoked?: string;
-	integrations?: Integration[];
-	verified: boolean;
-	friend_sync: boolean;
-	show_activity: boolean;
-	visibility: 0 | 1;
-}
+	export interface Connection {
+		id: string;
+		name: string;
+		type: string;
+		revoked?: string;
+		integrations?: Integration[];
+		verified: boolean;
+		friend_sync: boolean;
+		show_activity: boolean;
+		visibility: 0 | 1;
+	}
 
-interface Application {
-	id: string;
-	name: string;
-	icon: string | null | undefined;
-	description: string;
-	summary: string;
-	bot?: User;
-}
+	export interface Application {
+		id: string;
+		name: string;
+		icon: string | null | undefined;
+		description: string;
+		summary: string;
+		bot?: User;
+	}
 
-interface TokenRequestResult {
-	access_token: string;
-	token_type: string;
-	expires_in: number;
-	refresh_token: string;
-	scope: string;
-}
+	export interface TokenRequestResult {
+		access_token: string;
+		token_type: string;
+		expires_in: number;
+		refresh_token: string;
+		scope: string;
+	}
 
-interface PartialGuild {
-	id: string;
-	name: string;
-	icon: string | null | undefined;
-	owner?: boolean;
-	permissions?: number;
-	features: string[];
-	permissions_new?: string;
+	export interface PartialGuild {
+		id: string;
+		name: string;
+		icon: string | null | undefined;
+		owner?: boolean;
+		permissions?: number;
+		features: string[];
+		permissions_new?: string;
+	}
 }
 
 declare class OAuth extends EventEmitter {
@@ -105,11 +107,11 @@ declare class OAuth extends EventEmitter {
 		redirectUri?: string,
 		refreshToken?: string,
 		clientSecret?: string,
-	}): Promise<TokenRequestResult>;
+	}): Promise<OAuth.TokenRequestResult>;
 	revokeToken(access_token: string, credentials?: string): Promise<string>;
-	getUser(access_token: string): Promise<User>;
-	getUserGuilds(access_token: string): Promise<PartialGuild[]>;
-	getUserConnections(access_token: string): Promise<Connection[]>;
+	getUser(access_token: string): Promise<OAuth.User>;
+	getUserGuilds(access_token: string): Promise<OAuth.PartialGuild[]>;
+	getUserConnections(access_token: string): Promise<OAuth.Connection[]>;
 	addMember(opts: {
 		deaf?: boolean,
 		mute?: boolean,
@@ -119,7 +121,7 @@ declare class OAuth extends EventEmitter {
 		guildId: string,
 		botToken: string,
 		accessToken: string,
-	}): Promise<Member>;
+	}): Promise<OAuth.Member>;
 	generateAuthUrl(opts: {
 		scope: string[] | string,
 		state?: string,
@@ -132,5 +134,4 @@ declare class OAuth extends EventEmitter {
 		disableGuildSelect?: boolean,
 	}): string;
 }
-
 export = OAuth;


### PR DESCRIPTION
Every Interface is now exported. Because of the export assignment I had to wrap them inside a namespace.

Why?
Because now extend e.g. the `Express.Request.User` Interface with e.g. the `PartialGuild` Interface to store the Guilds inside the request object

<details><summary>Example:</summary>


declaration file
```ts
import { Profile } from '@oauth-everything/profile';

import { PartialGuild } from '../../../../discord-oauth2/index';

declare global {
  namespace Express {
    interface User extends Profile {
      guilds?: GuildInfo[];
    }
    interface Request {
      user?: User;
    }
  }
}

interface GuildInfo extends PartialGuild {
  /** User has MANAGE_GUILD Permission */
  hasPerms?: boolean;
  /** Bot is in Server */
  inGuild?: boolean;
}
```

express routes file
```ts
const userGuilds = await oauth.getUserGuilds(req.user.accessToken!);
  req.user.guilds = userGuilds;
  req.user!.guilds!.map((g) => {
    g.hasPerms = new Permissions(g.permissions).has('MANAGE_GUILD', true);
    g.inGuild = client.guilds.cache.has(g.id);
    return g;
  });
```


</details>