### PR TITLE
Add Guild to TokenRequestResult

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,12 +82,13 @@ declare namespace OAuth {
 		refresh_token: string;
 		scope: string;
 		webhook?: Webhook;
+		guild?: Guild;
 	}
 
 	export interface PartialGuild {
 		id: string;
 		name: string;
-		icon: string | null | undefined;
+		icon: string | null;
 		owner?: boolean;
 		permissions?: string;
 		features: string[];
@@ -99,12 +100,74 @@ declare namespace OAuth {
 		type: boolean;
 		id: string;
 		name: string;
-		avatar: string | null | undefined;
+		avatar: string | null;
 		channel_id: string;
 		guild_id: string;
 		application_id: string;
 		token: string;
 		url: string;
+	}
+
+	export interface Guild {
+		id: string;
+		name: string;
+		icon: string | null;
+		owner_id: string;
+		splash: string | null;
+		discovery_splash: string | null;
+		afk_channel_id: string | null;
+		afk_timeout: number;
+		widget_enabled?: boolean;
+		widget_channel_id?: string | null;
+		verification_level: number;
+		default_message_notifications: number;
+		explicit_content_filter: number;
+		explicit_content_filter: number;
+		roles: Role[];
+		emojis: Emoji[];
+		features: string[];
+		mfa_level: number;
+		application_id: string | null;
+		system_channel_id: string | null;
+		system_channel_flags: number;
+		rules_channel_id: string | null;
+		max_presences?: number | null;
+		max_members?: number;
+		vanity_url_code: string | null;
+		description: string | null;
+		banner: string | null;
+		premium_tier: number;
+		premium_subscription_count?: number;
+		preferred_locale: string;
+		public_updates_channel_id: string | null;
+		max_video_channel_users?: number;
+		max_stage_video_channel_users?: number;
+		safety_alerts_channel_id: string | null;
+	}
+
+	export interface Role {
+		id: string;
+		name: string;
+		color: number;
+		hoist: boolean;
+		icon?: string | null;
+		unicode_emoji?: string | null;
+		position: number;
+		permissions: string;
+		managed: boolean;
+		mentionable: boolean;
+		flags: number;
+	}
+
+	export interface Emoji {
+		id: string | null;
+		name: string | null;
+		roles?: string[];
+		user?: User;
+		require_colons?: boolean;
+		managed?: boolean;
+		animated?: boolean;
+		available?: boolean;
 	}
 
 	export interface HTTPResponse {


### PR DESCRIPTION
TokenRequestResult can include a full Guild object when using the `bot` scope: https://canary.discord.com/developers/docs/topics/oauth2#advanced-bot-authorization-extended-bot-authorization-access-token-example

Might be useful to look into [discordjs/discord-api-types](https://github.com/discordjs/discord-api-types) to export the types.